### PR TITLE
docs: add DCO guide in contributing

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,6 @@ at your option.
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
+
+Contributors should add a Signed-off-by line for [Developer Certificate of Origin](https://github.com/probot/dco#how-it-works)
+in their commits. Use `git commit -s` to sign off commits.


### PR DESCRIPTION
From a regulation perspective, DCO is not required for people inside this organization. But for other contributors, they should sign a DCO to certify that they wrote or otherwise have the right to submit the code they are contributing to the project.