### PR TITLE
chore: publish as v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2022-01-12
+
 ### Added
 
 - A command-line tool to run scripts from file against postgres-compatible databases.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "sqllogictest"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Sqllogictest parser and runner."
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 homepage = "https://github.com/singularity-data/sqllogictest-rs"
 repository = "https://github.com/singularity-data/sqllogictest-rs"
-keywords = ["sql", "database", "parser"]
+keywords = ["sql", "database", "parser", "cli"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add the following lines to your `Cargo.toml` file:
 
 ```toml
 [dependencies]
-sqllogictest = "0.1"
+sqllogictest = "0.2"
 ```
 
 Implement `DB` trait for your database structure:


### PR DESCRIPTION
We are going to publish the current version as v0.2.0.