### PR TITLE
fix(parser): keep newline char in sql

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -228,7 +228,7 @@ fn parse_inner(filename: Rc<str>, script: &str) -> Result<Vec<Record>, ParseErro
                     if line.is_empty() {
                         break;
                     }
-                    sql += " ";
+                    sql += "\n";
                     sql += line;
                 }
                 records.push(Record::Statement {
@@ -267,7 +267,7 @@ fn parse_inner(filename: Rc<str>, script: &str) -> Result<Vec<Record>, ParseErro
                         has_result = true;
                         break;
                     }
-                    sql += " ";
+                    sql += "\n";
                     sql += line;
                 }
                 // Lines following the "----" are expected results of the query, one value per line.


### PR DESCRIPTION
Signed-off-by: Runji Wang <wangrunji0408@163.com>

Currently the parser will replace all '\n' with ' ' in the input SQL, which makes it unreadable in error messages.