### PR TITLE
feat: support file-level sort mode control syntax

### DIFF
--- a/examples/file_level_sort_mode.rs
+++ b/examples/file_level_sort_mode.rs
@@ -1,0 +1,32 @@
+use std::path::Path;
+
+pub struct FakeDB;
+
+#[derive(Debug)]
+pub struct FakeDBError;
+
+impl std::fmt::Display for FakeDBError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl std::error::Error for FakeDBError {}
+
+impl sqllogictest::DB for FakeDB {
+    type Error = FakeDBError;
+
+    fn run(&mut self, sql: &str) -> Result<String, FakeDBError> {
+        if sql == "select * from example_file_level_sort_mode" {
+            // Even if the order is not the same as `slt` file, sqllogictest will sort them before comparing.
+            return Ok("1 10 2333\n2 20 2333\n10 100 2333".into());
+        }
+        unimplemented!("unsupported SQL: {}", sql);
+    }
+}
+
+fn main() {
+    let script = std::fs::read_to_string(Path::new("examples/file_level_sort_mode.slt")).unwrap();
+    let mut tester = sqllogictest::Runner::new(FakeDB);
+    tester.run_script(&script).unwrap();
+}

--- a/examples/file_level_sort_mode.slt
+++ b/examples/file_level_sort_mode.slt
@@ -1,0 +1,8 @@
+control sortmode rowsort
+
+query III
+select * from example_file_level_sort_mode
+----
+1 10 2333
+10 100 2333
+2 20 2333

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -49,7 +49,10 @@ impl Location {
 #[non_exhaustive]
 pub enum Record {
     /// An include copies all records from another files.
-    Include { loc: Location, filename: String },
+    Include {
+        loc: Location,
+        filename: String,
+    },
     /// A statement is an SQL command that is to be evaluated but from which we do not expect to
     /// get results (other than success or failure).
     Statement {
@@ -68,7 +71,7 @@ pub enum Record {
         loc: Location,
         conditions: Vec<Condition>,
         type_string: String,
-        sort_mode: SortMode,
+        sort_mode: Option<SortMode>,
         label: Option<String>,
         /// The SQL command.
         sql: String,
@@ -76,12 +79,27 @@ pub enum Record {
         expected_results: String,
     },
     /// A sleep period.
-    Sleep { loc: Location, duration: Duration },
+    Sleep {
+        loc: Location,
+        duration: Duration,
+    },
     /// Subtest.
-    Subtest { loc: Location, name: String },
+    Subtest {
+        loc: Location,
+        name: String,
+    },
     /// A halt record merely causes sqllogictest to ignore the rest of the test script.
     /// For debugging use only.
-    Halt { loc: Location },
+    Halt {
+        loc: Location,
+    },
+    Control(Control),
+    EOF,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum Control {
+    SortMode { sort_mode: SortMode, global: bool },
 }
 
 /// The condition to run a query.
@@ -106,6 +124,25 @@ pub enum SortMode {
     /// It works like rowsort except that it does not honor row groupings. Each individual result
     /// value is sorted on its own.
     ValueSort,
+}
+
+impl SortMode {
+    pub fn from_str(s: &str) -> Result<Self, ParseErrorKind> {
+        match s {
+            "nosort" => Ok(Self::NoSort),
+            "rowsort" => Ok(Self::RowSort),
+            "valuesort" => Ok(Self::ValueSort),
+            _ => Err(ParseErrorKind::InvalidSortMode(s.to_string())),
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::NoSort => "nosort",
+            Self::RowSort => "rowsort",
+            Self::ValueSort => "valuesort",
+        }
+    }
 }
 
 /// The error type for parsing sqllogictest.
@@ -145,6 +182,8 @@ pub enum ParseErrorKind {
     InvalidNumber(String),
     #[error("invalid duration: {0:?}")]
     InvalidDuration(String),
+    #[error("invalid control: {0:?}")]
+    InvalidControl(String),
 }
 
 impl ParseErrorKind {
@@ -240,13 +279,9 @@ fn parse_inner(filename: Rc<str>, script: &str) -> Result<Vec<Record>, ParseErro
                 });
             }
             ["query", type_string, res @ ..] => {
-                let sort_mode = match res.get(0) {
-                    None | Some(&"nosort") => SortMode::NoSort,
-                    Some(&"rowsort") => SortMode::RowSort,
-                    Some(&"valuesort") => SortMode::ValueSort,
-                    Some(mode) => {
-                        return Err(ParseErrorKind::InvalidSortMode(mode.to_string()).at(loc))
-                    }
+                let sort_mode = match res.get(0).map(|&s| SortMode::from_str(s)).transpose() {
+                    Ok(sm) => sm,
+                    Err(k) => return Err(k.at(loc)),
                 };
                 let label = res.get(1).map(|s| s.to_string());
                 // The SQL for the query is found on second an subsequent lines of the record
@@ -291,9 +326,27 @@ fn parse_inner(filename: Rc<str>, script: &str) -> Result<Vec<Record>, ParseErro
                     expected_results,
                 });
             }
+            ["control", res @ ..] => match res {
+                ["sortmode", values @ ..] => {
+                    let (sort_mode, global) = match values {
+                        [sort_mode, "global"] => (SortMode::from_str(sort_mode), true),
+                        [sort_mode] => (SortMode::from_str(sort_mode), false),
+                        _ => return Err(ParseErrorKind::InvalidLine(line.into()).at(loc)),
+                    };
+                    match (sort_mode, global) {
+                        (Ok(sort_mode), global) => {
+                            records.push(Record::Control(Control::SortMode { sort_mode, global }))
+                        }
+                        (Err(k), _) => return Err(k.at(loc)),
+                    }
+                }
+
+                _ => return Err(ParseErrorKind::InvalidLine(line.into()).at(loc)),
+            },
             _ => return Err(ParseErrorKind::InvalidLine(line.into()).at(loc)),
         }
     }
+    records.push(Record::EOF);
     Ok(records)
 }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -109,6 +109,8 @@ pub struct Runner<D: AsyncDB> {
     // validator is used for validate if the result of query equals to expected.
     validator: Validator,
     testdir: Option<TempDir>,
+    global_sort_mode: Option<SortMode>,
+    file_sort_mode: Option<SortMode>,
 }
 
 impl<D: AsyncDB> Runner<D> {
@@ -118,6 +120,8 @@ impl<D: AsyncDB> Runner<D> {
             db,
             validator: |x, y| x == y,
             testdir: None,
+            global_sort_mode: None,
+            file_sort_mode: None,
         }
     }
 
@@ -190,13 +194,17 @@ impl<D: AsyncDB> Runner<D> {
                 };
                 let mut output = split_lines_and_normalize(&output);
                 let mut expected_results = split_lines_and_normalize(&expected_results);
-                match sort_mode {
-                    SortMode::NoSort => {}
-                    SortMode::RowSort => {
+                match sort_mode.as_ref().or(self
+                    .file_sort_mode
+                    .as_ref()
+                    .or(self.global_sort_mode.as_ref()))
+                {
+                    None | Some(SortMode::NoSort) => {}
+                    Some(SortMode::RowSort) => {
                         output.sort_unstable();
                         expected_results.sort_unstable();
                     }
-                    SortMode::ValueSort => todo!("value sort"),
+                    Some(SortMode::ValueSort) => todo!("value sort"),
                 };
                 if !(self.validator)(&output, &expected_results) {
                     return Err(TestErrorKind::QueryResultMismatch {
@@ -213,6 +221,16 @@ impl<D: AsyncDB> Runner<D> {
             Record::Include { loc, .. } => {
                 unreachable!("include should be rewritten during link: at {}", loc)
             }
+            Record::Control(control) => match control {
+                Control::SortMode { sort_mode, global } => {
+                    if global {
+                        self.global_sort_mode = Some(sort_mode);
+                    } else {
+                        self.file_sort_mode = Some(sort_mode);
+                    }
+                }
+            },
+            Record::EOF => self.file_sort_mode = None,
         }
         Ok(())
     }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -192,7 +192,7 @@ impl<D: AsyncDB> Runner<D> {
                 };
                 let mut output = split_lines_and_normalize(&output);
                 let mut expected_results = split_lines_and_normalize(&expected_results);
-                match sort_mode.as_ref().or(self.sort_mode.as_ref()) {
+                match sort_mode.as_ref().or_else(|| self.sort_mode.as_ref()) {
                     None | Some(SortMode::NoSort) => {}
                     Some(SortMode::RowSort) => {
                         output.sort_unstable();


### PR DESCRIPTION
As in #24 , we need a syntax to control the file-level sort mode.

This pr introduce syntax `control sortmode {sort_mode}` to do it.